### PR TITLE
Enable u-boot verified boot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-boot/*.img
+boot/out
+boot/keys
 boot/*.dtb
 boot/zImage*
 build/*

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To give you some sense of what we want to create:
 
 Prerequisites:
 ```
-sudo apt-get install gcc-arm-none-eabi mtd-utils u-boot-tools golang-1.10 fakeroot flex bison device-tree-compiler
+sudo apt-get install gcc-arm-none-eabi mtd-utils golang-1.10 fakeroot flex bison device-tree-compiler
 
 # Until u-root vendoring is working properly, also grab:
 go get -u github.com/u-root/u-bmc/cmd/uinit

--- a/boot/sign.its
+++ b/boot/sign.its
@@ -1,0 +1,42 @@
+/dts-v1/;
+/ {
+	description = "u-bmc";
+	#address-cells = <1>;
+
+	images {
+		kernel-1 {
+			data = /incbin/("zImage");
+			type = "kernel";
+			arch = "arm";
+			os = "linux";
+			compression = "none";
+			load = <0x40008000>;
+			entry = <0x40008000>;
+			hash-1 {
+				algo = "sha256";
+			};
+		};
+		fdt-1 {
+			description = "platform";
+			data = /incbin/("PLATFORM.dtb");
+			type = "flat_dt";
+			arch = "arm";
+			compression = "none";
+			hash-1 {
+				algo = "sha256";
+			};
+		};
+	};
+	configurations {
+		default = "conf-1";
+		conf-1 {
+			kernel = "kernel-1";
+			fdt = "fdt-1";
+			signature-1 {
+				algo = "sha256,rsa2048";
+				key-name-hint = "u-bmc";
+				sign-images = "fdt", "kernel";
+			};
+		};
+	};
+};

--- a/boot/u-boot.boot
+++ b/boot/u-boot.boot
@@ -1,5 +1,0 @@
-ubifsload 0x40000000 u-boot.env
-env import -t 0x40000000
-ubifsload 0x40000000 quanta-f06-leopard-ddr3.dtb
-ubifsload 0x40008000 zImage
-bootz 0x40008000 - 0x40000000

--- a/boot/u-boot.env
+++ b/boot/u-boot.env
@@ -1,1 +1,0 @@
-bootargs=console=ttyS4,57600n8 earlyprintk panic=1 ubi.mtd=ubi root=ubi0:root rootfstype=ubifs init=/init rw

--- a/platform/quanta-f06-leopard-ddr3.dts
+++ b/platform/quanta-f06-leopard-ddr3.dts
@@ -10,7 +10,7 @@
 
 	chosen {
 		stdout-path = &uart5;
-		bootargs = "console=ttyS4,57600n8 earlyprintk";
+		bootargs = "console=ttyS4,57600n8 earlyprintk panic=1 ubi.mtd=ubi root=ubi0:root rootfstype=ubifs init=/init rw";
 	};
 
 	memory@40000000 {

--- a/u-boot.config
+++ b/u-boot.config
@@ -169,6 +169,7 @@ CONFIG_ASPEED_NET_NCSI=y
 #
 # CONFIG_DEBUG_LL is not set
 # CONFIG_DM_KEYBOARD is not set
+CONFIG_DEFAULT_DEVICE_TREE=""
 # CONFIG_AHCI is not set
 
 #
@@ -184,11 +185,15 @@ CONFIG_SYS_MALLOC_CLEAR_ON_INIT=y
 #
 # Boot images
 #
-# CONFIG_FIT is not set
+CONFIG_FIT=y
+CONFIG_FIT_VERBOSE=y
+CONFIG_FIT_SIGNATURE=y
+# CONFIG_FIT_BEST_MATCH is not set
 # CONFIG_OF_BOARD_SETUP is not set
 # CONFIG_OF_SYSTEM_SETUP is not set
 # CONFIG_OF_STDOUT_VIA_ALIAS is not set
 CONFIG_SYS_EXTRA_OPTIONS=""
+# CONFIG_SPL_LOAD_FIT is not set
 
 #
 # Boot timing
@@ -343,7 +348,9 @@ CONFIG_SUPPORT_OF_CONTROL=y
 #
 # Device Tree Control
 #
-# CONFIG_OF_CONTROL is not set
+CONFIG_OF_CONTROL=y
+CONFIG_OF_SEPARATE=y
+# CONFIG_OF_EMBED is not set
 CONFIG_NET=y
 # CONFIG_NET_RANDOM_ETHADDR is not set
 # CONFIG_NETCONSOLE is not set
@@ -367,6 +374,8 @@ CONFIG_DM_SEQ_ALIAS=y
 # CONFIG_REGMAP is not set
 # CONFIG_SPL_REGMAP is not set
 # CONFIG_DEVRES is not set
+CONFIG_SIMPLE_BUS=y
+CONFIG_OF_TRANSLATE=y
 # CONFIG_ADC is not set
 # CONFIG_ADC_EXYNOS is not set
 # CONFIG_ADC_SANDBOX is not set
@@ -422,6 +431,7 @@ CONFIG_DM_SEQ_ALIAS=y
 #
 # Mailbox Controller Support
 #
+# CONFIG_DM_MAILBOX is not set
 
 #
 # Memory Controller drivers
@@ -496,6 +506,7 @@ CONFIG_MTD=y
 #
 # Reset Controller Support
 #
+# CONFIG_DM_RESET is not set
 
 #
 # Real Time Clock
@@ -550,6 +561,7 @@ CONFIG_SYS_NS16550=y
 # CONFIG_VIDEO_LCD_SSD2828 is not set
 # CONFIG_VIDEO_MVEBU is not set
 # CONFIG_DISPLAY is not set
+# CONFIG_VIDEO_TEGRA20 is not set
 # CONFIG_VIDEO_BRIDGE is not set
 # CONFIG_PHYS_TO_BUS is not set
 
@@ -560,7 +572,7 @@ CONFIG_SYS_NS16550=y
 #
 # Library routines
 #
-# CONFIG_CC_OPTIMIZE_LIBS_FOR_SPEED is not set
+CONFIG_CC_OPTIMIZE_LIBS_FOR_SPEED=y
 CONFIG_HAVE_PRIVATE_LIBGCC=y
 CONFIG_USE_PRIVATE_LIBGCC=y
 CONFIG_SYS_HZ=1000
@@ -568,14 +580,16 @@ CONFIG_SYS_HZ=1000
 CONFIG_REGEX=y
 # CONFIG_LIB_RAND is not set
 # CONFIG_CMD_DHRYSTONE is not set
-# CONFIG_RSA is not set
+CONFIG_RSA=y
+# CONFIG_SPL_RSA is not set
+CONFIG_RSA_SOFTWARE_EXP=y
 # CONFIG_TPM is not set
 
 #
 # Hashing Support
 #
 # CONFIG_SHA1 is not set
-# CONFIG_SHA256 is not set
+CONFIG_SHA256=y
 # CONFIG_SHA_HW_ACCEL is not set
 
 #


### PR DESCRIPTION
Create keys and sign the kernel + DTB and enable mandatory image
verification.

This is part of #57 and is useless right now as userspace can just
replace any part anyway, but let's take this in small iterations.

Signed-off-by: Christian Svensson <bluecmd@google.com>