### PR TITLE
Add NCSI MAC OEM support for ConnectX-3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,9 @@ boot/%.dtb: platform/%.dts platform/ubmc-flash-layout.dtsi
 root.ubifs.img: initramfs.cpio boot.img boot/signer/signer
 	rm -fr root/
 	mkdir -p root/root root/etc root/boot
+	echo "nameserver 2001:4860:4860::8888" > root/etc/resolv.conf
+	echo "nameserver 2606:4700:4700::1111" >> root/etc/resolv.conf
+	echo "nameserver 8.8.8.8" >> root/etc/resolv.conf
 	cp -v boot.img root/boot/
 	cp -v $(ROOT_DIR)/boot/keys/u-bmc.pub root/etc/
 	ln -sf /bbin/bb.sig root/init.sig

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ cd ~/go/src/github.com/u-root/u-bmc
 git submodule init && git submodule update
 # Until https://github.com/u-root/u-root/issues/936 is fixed
 rm -r ~/go/src/github.com/u-root/u-root/vendor/google.golang.org/grpc/codes
+(cd linux/; ../linux-patches/apply.sh)
 ```
 
 Setup:

--- a/linux-patches/01-net-next-net-ncsi-Add-NCSI-OEM-command-support.diff
+++ b/linux-patches/01-net-next-net-ncsi-Add-NCSI-OEM-command-support.diff
@@ -1,0 +1,164 @@
+diff --git a/net/ncsi/internal.h b/net/ncsi/internal.h
+index 8055e3965cef..3d0a33b874f5 100644
+--- a/net/ncsi/internal.h
++++ b/net/ncsi/internal.h
+@@ -68,6 +68,10 @@ enum {
+ 	NCSI_MODE_MAX
+ };
+ 
++/* OEM Vendor Manufacture ID */
++#define NCSI_OEM_MFR_MLX_ID             0x8119
++#define NCSI_OEM_MFR_BCM_ID             0x113d
++
+ struct ncsi_channel_version {
+ 	u32 version;		/* Supported BCD encoded NCSI version */
+ 	u32 alpha2;		/* Supported BCD encoded NCSI version */
+@@ -305,6 +309,7 @@ struct ncsi_cmd_arg {
+ 		unsigned short words[8];
+ 		unsigned int   dwords[4];
+ 	};
++	unsigned char        *data;       /* NCSI OEM data                 */
+ };
+ 
+ extern struct list_head ncsi_dev_list;
+diff --git a/net/ncsi/ncsi-cmd.c b/net/ncsi/ncsi-cmd.c
+index 7567ca63aae2..82b7d9201db8 100644
+--- a/net/ncsi/ncsi-cmd.c
++++ b/net/ncsi/ncsi-cmd.c
+@@ -211,6 +211,25 @@ static int ncsi_cmd_handler_snfc(struct sk_buff *skb,
+ 	return 0;
+ }
+ 
++static int ncsi_cmd_handler_oem(struct sk_buff *skb,
++				struct ncsi_cmd_arg *nca)
++{
++	struct ncsi_cmd_oem_pkt *cmd;
++	unsigned int len;
++
++	len = sizeof(struct ncsi_cmd_pkt_hdr) + 4;
++	if (nca->payload < 26)
++		len += 26;
++	else
++		len += nca->payload;
++
++	cmd = skb_put_zero(skb, len);
++	memcpy(&cmd->mfr_id, nca->data, nca->payload);
++	ncsi_cmd_build_header(&cmd->cmd.common, nca);
++
++	return 0;
++}
++
+ static struct ncsi_cmd_handler {
+ 	unsigned char type;
+ 	int           payload;
+@@ -244,7 +263,7 @@ static struct ncsi_cmd_handler {
+ 	{ NCSI_PKT_CMD_GNS,    0, ncsi_cmd_handler_default },
+ 	{ NCSI_PKT_CMD_GNPTS,  0, ncsi_cmd_handler_default },
+ 	{ NCSI_PKT_CMD_GPS,    0, ncsi_cmd_handler_default },
+-	{ NCSI_PKT_CMD_OEM,    0, NULL                     },
++	{ NCSI_PKT_CMD_OEM,   -1, ncsi_cmd_handler_oem     },
+ 	{ NCSI_PKT_CMD_PLDM,   0, NULL                     },
+ 	{ NCSI_PKT_CMD_GPUUID, 0, ncsi_cmd_handler_default }
+ };
+@@ -316,8 +335,13 @@ int ncsi_xmit_cmd(struct ncsi_cmd_arg *nca)
+ 		return -ENOENT;
+ 	}
+ 
+-	/* Get packet payload length and allocate the request */
+-	nca->payload = nch->payload;
++	/* Get packet payload length and allocate the request
++	 * It is expected that if length set as negative in
++	 * handler structure means caller is initializing it
++	 * and setting length in nca before calling xmit function
++	 */
++	if (nch->payload >= 0)
++		nca->payload = nch->payload;
+ 	nr = ncsi_alloc_command(nca);
+ 	if (!nr)
+ 		return -ENOMEM;
+diff --git a/net/ncsi/ncsi-pkt.h b/net/ncsi/ncsi-pkt.h
+index 91b4b66438df..0f2087c8d42a 100644
+--- a/net/ncsi/ncsi-pkt.h
++++ b/net/ncsi/ncsi-pkt.h
+@@ -151,6 +151,20 @@ struct ncsi_cmd_snfc_pkt {
+ 	unsigned char           pad[22];
+ };
+ 
++/* OEM Request Command as per NCSI Specification */
++struct ncsi_cmd_oem_pkt {
++	struct ncsi_cmd_pkt_hdr cmd;         /* Command header    */
++	__be32                  mfr_id;      /* Manufacture ID    */
++	unsigned char           data[];      /* OEM Payload Data  */
++};
++
++/* OEM Response Packet as per NCSI Specification */
++struct ncsi_rsp_oem_pkt {
++	struct ncsi_rsp_pkt_hdr rsp;         /* Command header    */
++	__be32                  mfr_id;      /* Manufacture ID    */
++	unsigned char           data[];      /* Payload data      */
++};
++
+ /* Get Link Status */
+ struct ncsi_rsp_gls_pkt {
+ 	struct ncsi_rsp_pkt_hdr rsp;        /* Response header   */
+diff --git a/net/ncsi/ncsi-rsp.c b/net/ncsi/ncsi-rsp.c
+index 930c1d3796f0..d66b34749027 100644
+--- a/net/ncsi/ncsi-rsp.c
++++ b/net/ncsi/ncsi-rsp.c
+@@ -596,6 +596,47 @@ static int ncsi_rsp_handler_snfc(struct ncsi_request *nr)
+ 	return 0;
+ }
+ 
++static struct ncsi_rsp_oem_handler {
++	unsigned int	mfr_id;
++	int		(*handler)(struct ncsi_request *nr);
++} ncsi_rsp_oem_handlers[] = {
++	{ NCSI_OEM_MFR_MLX_ID, NULL },
++	{ NCSI_OEM_MFR_BCM_ID, NULL }
++};
++
++/* Response handler for OEM command */
++static int ncsi_rsp_handler_oem(struct ncsi_request *nr)
++{
++	struct ncsi_rsp_oem_pkt *rsp;
++	struct ncsi_rsp_oem_handler *nrh = NULL;
++	unsigned int mfr_id, i;
++
++	/* Get the response header */
++	rsp = (struct ncsi_rsp_oem_pkt *)skb_network_header(nr->rsp);
++	mfr_id = ntohl(rsp->mfr_id);
++
++	/* Check for manufacturer id and Find the handler */
++	for (i = 0; i < ARRAY_SIZE(ncsi_rsp_oem_handlers); i++) {
++		if (ncsi_rsp_oem_handlers[i].mfr_id == mfr_id) {
++			if (ncsi_rsp_oem_handlers[i].handler)
++				nrh = &ncsi_rsp_oem_handlers[i];
++			else
++				nrh = NULL;
++
++			break;
++		}
++	}
++
++	if (!nrh) {
++		netdev_err(nr->ndp->ndev.dev, "Received unrecognized OEM packet with MFR-ID (0x%x)\n",
++			   mfr_id);
++		return -ENOENT;
++	}
++
++	/* Process the packet */
++	return nrh->handler(nr);
++}
++
+ static int ncsi_rsp_handler_gvi(struct ncsi_request *nr)
+ {
+ 	struct ncsi_rsp_gvi_pkt *rsp;
+@@ -932,7 +973,7 @@ static struct ncsi_rsp_handler {
+ 	{ NCSI_PKT_RSP_GNS,   172, ncsi_rsp_handler_gns     },
+ 	{ NCSI_PKT_RSP_GNPTS, 172, ncsi_rsp_handler_gnpts   },
+ 	{ NCSI_PKT_RSP_GPS,     8, ncsi_rsp_handler_gps     },
+-	{ NCSI_PKT_RSP_OEM,     0, NULL                     },
++	{ NCSI_PKT_RSP_OEM,    -1, ncsi_rsp_handler_oem     },
+ 	{ NCSI_PKT_RSP_PLDM,    0, NULL                     },
+ 	{ NCSI_PKT_RSP_GPUUID, 20, ncsi_rsp_handler_gpuuid  }
+ };

--- a/linux-patches/02-v2-1-2-net-ncsi-Add-NCSI-Broadcom-OEM-command.diff
+++ b/linux-patches/02-v2-1-2-net-ncsi-Add-NCSI-Broadcom-OEM-command.diff
@@ -1,0 +1,212 @@
+diff --git a/net/ncsi/Kconfig b/net/ncsi/Kconfig
+index 08a8a6031fd7..7f2b46108a24 100644
+--- a/net/ncsi/Kconfig
++++ b/net/ncsi/Kconfig
+@@ -10,3 +10,9 @@ config NET_NCSI
+ 	  support. Enable this only if your system connects to a network
+ 	  device via NCSI and the ethernet driver you're using supports
+ 	  the protocol explicitly.
++config NCSI_OEM_CMD_GET_MAC
++	bool "Get NCSI OEM MAC Address"
++	depends on NET_NCSI
++	---help---
++	  This allows to get MAC address from NCSI firmware and set them back to
++		controller.
+diff --git a/net/ncsi/internal.h b/net/ncsi/internal.h
+index 3d0a33b874f5..45883b32790e 100644
+--- a/net/ncsi/internal.h
++++ b/net/ncsi/internal.h
+@@ -71,6 +71,13 @@ enum {
+ /* OEM Vendor Manufacture ID */
+ #define NCSI_OEM_MFR_MLX_ID             0x8119
+ #define NCSI_OEM_MFR_BCM_ID             0x113d
++/* Broadcom specific OEM Command */
++#define NCSI_OEM_BCM_CMD_GMA            0x01   /* CMD ID for Get MAC */
++/* OEM Command payload lengths*/
++#define NCSI_OEM_BCM_CMD_GMA_LEN        12
++/* Mac address offset in OEM response */
++#define BCM_MAC_ADDR_OFFSET             28
++
+ 
+ struct ncsi_channel_version {
+ 	u32 version;		/* Supported BCD encoded NCSI version */
+@@ -240,6 +247,7 @@ enum {
+ 	ncsi_dev_state_probe_dp,
+ 	ncsi_dev_state_config_sp	= 0x0301,
+ 	ncsi_dev_state_config_cis,
++	ncsi_dev_state_config_oem_gma,
+ 	ncsi_dev_state_config_clear_vids,
+ 	ncsi_dev_state_config_svf,
+ 	ncsi_dev_state_config_ev,
+diff --git a/net/ncsi/ncsi-manage.c b/net/ncsi/ncsi-manage.c
+index 091284760d21..e5bfd9245b5d 100644
+--- a/net/ncsi/ncsi-manage.c
++++ b/net/ncsi/ncsi-manage.c
+@@ -635,6 +635,39 @@ static int set_one_vid(struct ncsi_dev_priv *ndp, struct ncsi_channel *nc,
+ 	return 0;
+ }
+ 
++#if IS_ENABLED(CONFIG_NCSI_OEM_CMD_GET_MAC)
++
++/* NCSI OEM Command APIs */
++static void ncsi_oem_gma_handler_bcm(struct ncsi_cmd_arg *nca)
++{
++	int ret = 0;
++	unsigned char data[NCSI_OEM_BCM_CMD_GMA_LEN];
++
++	nca->payload = NCSI_OEM_BCM_CMD_GMA_LEN;
++
++	memset(data, 0, NCSI_OEM_BCM_CMD_GMA_LEN);
++	*(unsigned int *)data = ntohl(NCSI_OEM_MFR_BCM_ID);
++	data[5] = NCSI_OEM_BCM_CMD_GMA;
++
++	nca->data = data;
++
++	ret = ncsi_xmit_cmd(nca);
++	if (ret)
++		netdev_err(nca->ndp->ndev.dev,
++			   "NCSI: Failed to transmit cmd 0x%x during configure\n",
++			   nca->type);
++}
++
++/* OEM Command handlers initialization */
++static struct ncsi_oem_gma_handler {
++	unsigned int	mfr_id;
++	void		(*handler)(struct ncsi_cmd_arg *nca);
++} ncsi_oem_gma_handlers[] = {
++	{ NCSI_OEM_MFR_BCM_ID, ncsi_oem_gma_handler_bcm }
++};
++
++#endif /* CONFIG_NCSI_OEM_CMD_GET_MAC */
++
+ static void ncsi_configure_channel(struct ncsi_dev_priv *ndp)
+ {
+ 	struct ncsi_dev *nd = &ndp->ndev;
+@@ -643,9 +676,10 @@ static void ncsi_configure_channel(struct ncsi_dev_priv *ndp)
+ 	struct ncsi_channel *nc = ndp->active_channel;
+ 	struct ncsi_channel *hot_nc = NULL;
+ 	struct ncsi_cmd_arg nca;
++	struct ncsi_oem_gma_handler *nch = NULL;
+ 	unsigned char index;
+ 	unsigned long flags;
+-	int ret;
++	int ret, i;
+ 
+ 	nca.ndp = ndp;
+ 	nca.req_flags = NCSI_REQ_FLAG_EVENT_DRIVEN;
+@@ -685,6 +719,40 @@ static void ncsi_configure_channel(struct ncsi_dev_priv *ndp)
+ 			goto error;
+ 		}
+ 
++#if IS_ENABLED(CONFIG_NCSI_OEM_CMD_GET_MAC)
++		nd->state = ncsi_dev_state_config_oem_gma;
++		break;
++	case ncsi_dev_state_config_oem_gma:
++		nca.type = NCSI_PKT_CMD_OEM;
++		nca.package = np->id;
++		nca.channel = nc->id;
++		ndp->pending_req_num = 1;
++
++		/* Check for manufacturer id and Find the handler */
++		for (i = 0; i < ARRAY_SIZE(ncsi_oem_gma_handlers); i++) {
++			if (ncsi_oem_gma_handlers[i].mfr_id ==
++					nc->version.mf_id) {
++				if (ncsi_oem_gma_handlers[i].handler)
++					nch = &ncsi_oem_gma_handlers[i];
++				else
++					nch = NULL;
++
++				break;
++			}
++		}
++
++		if (!nch) {
++			netdev_err(ndp->ndev.dev, "No handler available for GMA with MFR-ID (0x%x)\n",
++				   nc->version.mf_id);
++			nd->state = ncsi_dev_state_config_clear_vids;
++			schedule_work(&ndp->work);
++			break;
++		}
++
++		/* Get Mac address from NCSI device */
++		nch->handler(&nca);
++#endif /* CONFIG_NCSI_OEM_CMD_GET_MAC */
++
+ 		nd->state = ncsi_dev_state_config_clear_vids;
+ 		break;
+ 	case ncsi_dev_state_config_clear_vids:
+diff --git a/net/ncsi/ncsi-pkt.h b/net/ncsi/ncsi-pkt.h
+index 0f2087c8d42a..4d3f06be38bd 100644
+--- a/net/ncsi/ncsi-pkt.h
++++ b/net/ncsi/ncsi-pkt.h
+@@ -165,6 +165,14 @@ struct ncsi_rsp_oem_pkt {
+ 	unsigned char           data[];      /* Payload data      */
+ };
+ 
++/* Broadcom Response Data */
++struct ncsi_rsp_oem_bcm_pkt {
++	unsigned char           ver;         /* Payload Version   */
++	unsigned char           type;        /* OEM Command type  */
++	__be16                  len;         /* Payload Length    */
++	unsigned char           data[];      /* Cmd specific Data */
++};
++
+ /* Get Link Status */
+ struct ncsi_rsp_gls_pkt {
+ 	struct ncsi_rsp_pkt_hdr rsp;        /* Response header   */
+diff --git a/net/ncsi/ncsi-rsp.c b/net/ncsi/ncsi-rsp.c
+index d66b34749027..31672e967db2 100644
+--- a/net/ncsi/ncsi-rsp.c
++++ b/net/ncsi/ncsi-rsp.c
+@@ -596,12 +596,50 @@ static int ncsi_rsp_handler_snfc(struct ncsi_request *nr)
+ 	return 0;
+ }
+ 
++/* Response handler for Broadcom command Get Mac Address */
++static int ncsi_rsp_handler_oem_bcm_gma(struct ncsi_request *nr)
++{
++	struct ncsi_rsp_oem_pkt *rsp;
++	struct ncsi_dev_priv *ndp = nr->ndp;
++	struct net_device *ndev = ndp->ndev.dev;
++	int ret = 0;
++	const struct net_device_ops *ops = ndev->netdev_ops;
++	struct sockaddr saddr;
++
++	/* Get the response header */
++	rsp = (struct ncsi_rsp_oem_pkt *)skb_network_header(nr->rsp);
++
++	saddr.sa_family = ndev->type;
++	ndev->priv_flags |= IFF_LIVE_ADDR_CHANGE;
++	memcpy(saddr.sa_data, &rsp->data[BCM_MAC_ADDR_OFFSET], ETH_ALEN);
++	ret = ops->ndo_set_mac_address(ndev, &saddr);
++	if (ret < 0)
++		netdev_warn(ndev, "NCSI: Writing mac address to device failed\n");
++
++	return ret;
++}
++
++/* Response handler for Broadcom card */
++static int ncsi_rsp_handler_oem_bcm(struct ncsi_request *nr)
++{
++	struct ncsi_rsp_oem_pkt *rsp;
++	struct ncsi_rsp_oem_bcm_pkt *bcm;
++
++	/* Get the response header */
++	rsp = (struct ncsi_rsp_oem_pkt *)skb_network_header(nr->rsp);
++	bcm = (struct ncsi_rsp_oem_bcm_pkt *)(rsp->data);
++
++	if (bcm->type == NCSI_OEM_BCM_CMD_GMA)
++		return ncsi_rsp_handler_oem_bcm_gma(nr);
++	return 0;
++}
++
+ static struct ncsi_rsp_oem_handler {
+ 	unsigned int	mfr_id;
+ 	int		(*handler)(struct ncsi_request *nr);
+ } ncsi_rsp_oem_handlers[] = {
+ 	{ NCSI_OEM_MFR_MLX_ID, NULL },
+-	{ NCSI_OEM_MFR_BCM_ID, NULL }
++	{ NCSI_OEM_MFR_BCM_ID, ncsi_rsp_handler_oem_bcm }
+ };
+ 
+ /* Response handler for OEM command */

--- a/linux-patches/03-net-next-v3-2-2-net-ncsi-Add-NCSI-Mellanox-OEM-command.diff
+++ b/linux-patches/03-net-next-v3-2-2-net-ncsi-Add-NCSI-Mellanox-OEM-command.diff
@@ -1,0 +1,139 @@
+diff --git a/net/ncsi/internal.h b/net/ncsi/internal.h
+index 45883b32790e..d4558628a991 100644
+--- a/net/ncsi/internal.h
++++ b/net/ncsi/internal.h
+@@ -73,10 +73,15 @@ enum {
+ #define NCSI_OEM_MFR_BCM_ID             0x113d
+ /* Broadcom specific OEM Command */
+ #define NCSI_OEM_BCM_CMD_GMA            0x01   /* CMD ID for Get MAC */
++/* Mellanox specific OEM Command */
++#define NCSI_OEM_MLX_CMD_GMA            0x00   /* CMD ID for Get MAC */
++#define NCSI_OEM_MLX_CMD_GMA_PARAM      0x1b   /* Parameter for GMA  */
+ /* OEM Command payload lengths*/
+ #define NCSI_OEM_BCM_CMD_GMA_LEN        12
++#define NCSI_OEM_MLX_CMD_GMA_LEN        8
+ /* Mac address offset in OEM response */
+ #define BCM_MAC_ADDR_OFFSET             28
++#define MLX_MAC_ADDR_OFFSET             8
+ 
+ 
+ struct ncsi_channel_version {
+diff --git a/net/ncsi/ncsi-manage.c b/net/ncsi/ncsi-manage.c
+index 75504ccd1b95..9306fa464190 100644
+--- a/net/ncsi/ncsi-manage.c
++++ b/net/ncsi/ncsi-manage.c
+@@ -658,12 +658,34 @@ static void ncsi_oem_gma_handler_bcm(struct ncsi_cmd_arg *nca)
+ 			   nca->type);
+ }
+ 
++static void ncsi_oem_gma_handler_mlx(struct ncsi_cmd_arg *nca)
++{
++	int ret = 0;
++	unsigned char data[NCSI_OEM_MLX_CMD_GMA_LEN];
++
++	nca->payload = NCSI_OEM_MLX_CMD_GMA_LEN;
++
++	memset(data, 0, NCSI_OEM_MLX_CMD_GMA_LEN);
++	*(unsigned int *)data = ntohl(NCSI_OEM_MFR_MLX_ID);
++	data[5] = NCSI_OEM_MLX_CMD_GMA;
++	data[6] = NCSI_OEM_MLX_CMD_GMA_PARAM;
++
++	nca->data = data;
++
++	ret = ncsi_xmit_cmd(nca);
++	if (ret)
++		netdev_err(nca->ndp->ndev.dev,
++			   "NCSI: Failed to transmit cmd 0x%x during configure\n",
++			   nca->type);
++}
++
+ /* OEM Command handlers initialization */
+ static struct ncsi_oem_gma_handler {
+ 	unsigned int	mfr_id;
+ 	void		(*handler)(struct ncsi_cmd_arg *nca);
+ } ncsi_oem_gma_handlers[] = {
+-	{ NCSI_OEM_MFR_BCM_ID, ncsi_oem_gma_handler_bcm }
++	{ NCSI_OEM_MFR_BCM_ID, ncsi_oem_gma_handler_bcm },
++	{ NCSI_OEM_MFR_MLX_ID, ncsi_oem_gma_handler_mlx }
+ };
+ 
+ #endif /* CONFIG_NCSI_OEM_CMD_GET_MAC */
+diff --git a/net/ncsi/ncsi-pkt.h b/net/ncsi/ncsi-pkt.h
+index 4d3f06be38bd..2a6d83a596c9 100644
+--- a/net/ncsi/ncsi-pkt.h
++++ b/net/ncsi/ncsi-pkt.h
+@@ -165,6 +165,15 @@ struct ncsi_rsp_oem_pkt {
+ 	unsigned char           data[];      /* Payload data      */
+ };
+ 
++/* Mellanox Response Data */
++struct ncsi_rsp_oem_mlx_pkt {
++	unsigned char           cmd_rev;     /* Command Revision  */
++	unsigned char           cmd;         /* Command ID        */
++	unsigned char           param;       /* Parameter         */
++	unsigned char           optional;    /* Optional data     */
++	unsigned char           data[];      /* Data              */
++};
++
+ /* Broadcom Response Data */
+ struct ncsi_rsp_oem_bcm_pkt {
+ 	unsigned char           ver;         /* Payload Version   */
+diff --git a/net/ncsi/ncsi-rsp.c b/net/ncsi/ncsi-rsp.c
+index 31672e967db2..5158836796ce 100644
+--- a/net/ncsi/ncsi-rsp.c
++++ b/net/ncsi/ncsi-rsp.c
+@@ -596,6 +596,45 @@ static int ncsi_rsp_handler_snfc(struct ncsi_request *nr)
+ 	return 0;
+ }
+ 
++/* Response handler for Mellanox command Get Mac Address */
++static int ncsi_rsp_handler_oem_mlx_gma(struct ncsi_request *nr)
++{
++	struct ncsi_rsp_oem_pkt *rsp;
++	struct ncsi_dev_priv *ndp = nr->ndp;
++	struct net_device *ndev = ndp->ndev.dev;
++	int ret = 0;
++	const struct net_device_ops *ops = ndev->netdev_ops;
++	struct sockaddr saddr;
++
++	/* Get the response header */
++	rsp = (struct ncsi_rsp_oem_pkt *)skb_network_header(nr->rsp);
++
++	saddr.sa_family = ndev->type;
++	ndev->priv_flags |= IFF_LIVE_ADDR_CHANGE;
++	memcpy(saddr.sa_data, &rsp->data[MLX_MAC_ADDR_OFFSET], ETH_ALEN);
++	ret = ops->ndo_set_mac_address(ndev, &saddr);
++	if (ret < 0)
++		netdev_warn(ndev, "NCSI: Writing mac address to device failed\n");
++
++	return ret;
++}
++
++/* Response handler for Mellanox card */
++static int ncsi_rsp_handler_oem_mlx(struct ncsi_request *nr)
++{
++	struct ncsi_rsp_oem_pkt *rsp;
++	struct ncsi_rsp_oem_mlx_pkt *mlx;
++
++	/* Get the response header */
++	rsp = (struct ncsi_rsp_oem_pkt *)skb_network_header(nr->rsp);
++	mlx = (struct ncsi_rsp_oem_mlx_pkt *)(rsp->data);
++
++	if (mlx->cmd == NCSI_OEM_MLX_CMD_GMA &&
++	    mlx->param == NCSI_OEM_MLX_CMD_GMA_PARAM)
++		return ncsi_rsp_handler_oem_mlx_gma(nr);
++	return 0;
++}
++
+ /* Response handler for Broadcom command Get Mac Address */
+ static int ncsi_rsp_handler_oem_bcm_gma(struct ncsi_request *nr)
+ {
+@@ -638,7 +677,7 @@ static struct ncsi_rsp_oem_handler {
+ 	unsigned int	mfr_id;
+ 	int		(*handler)(struct ncsi_request *nr);
+ } ncsi_rsp_oem_handlers[] = {
+-	{ NCSI_OEM_MFR_MLX_ID, NULL },
++	{ NCSI_OEM_MFR_MLX_ID, ncsi_rsp_handler_oem_mlx },
+ 	{ NCSI_OEM_MFR_BCM_ID, ncsi_rsp_handler_oem_bcm }
+ };
+ 

--- a/linux-patches/04-net-next-v7-net-ncsi-Extend-NC-SI-Netlink-interface-to-allow-user-space-to-send-NC-SI-command.diff
+++ b/linux-patches/04-net-next-v7-net-ncsi-Extend-NC-SI-Netlink-interface-to-allow-user-space-to-send-NC-SI-command.diff
@@ -1,0 +1,523 @@
+diff --git a/include/uapi/linux/ncsi.h b/include/uapi/linux/ncsi.h
+index 4c292ec..0a26a55 100644
+--- a/include/uapi/linux/ncsi.h
++++ b/include/uapi/linux/ncsi.h
+@@ -23,6 +23,9 @@
+  *	optionally the preferred NCSI_ATTR_CHANNEL_ID.
+  * @NCSI_CMD_CLEAR_INTERFACE: clear any preferred package/channel combination.
+  *	Requires NCSI_ATTR_IFINDEX.
++ * @NCSI_CMD_SEND_CMD: send NC-SI command to network card.
++ *	Requires NCSI_ATTR_IFINDEX, NCSI_ATTR_PACKAGE_ID
++ *	and NCSI_ATTR_CHANNEL_ID.
+  * @NCSI_CMD_MAX: highest command number
+  */
+ enum ncsi_nl_commands {
+@@ -30,6 +33,7 @@ enum ncsi_nl_commands {
+ 	NCSI_CMD_PKG_INFO,
+ 	NCSI_CMD_SET_INTERFACE,
+ 	NCSI_CMD_CLEAR_INTERFACE,
++	NCSI_CMD_SEND_CMD,
+ 
+ 	__NCSI_CMD_AFTER_LAST,
+ 	NCSI_CMD_MAX = __NCSI_CMD_AFTER_LAST - 1
+@@ -43,6 +47,7 @@ enum ncsi_nl_commands {
+  * @NCSI_ATTR_PACKAGE_LIST: nested array of NCSI_PKG_ATTR attributes
+  * @NCSI_ATTR_PACKAGE_ID: package ID
+  * @NCSI_ATTR_CHANNEL_ID: channel ID
++ * @NCSI_ATTR_DATA: command payload
+  * @NCSI_ATTR_MAX: highest attribute number
+  */
+ enum ncsi_nl_attrs {
+@@ -51,6 +56,7 @@ enum ncsi_nl_attrs {
+ 	NCSI_ATTR_PACKAGE_LIST,
+ 	NCSI_ATTR_PACKAGE_ID,
+ 	NCSI_ATTR_CHANNEL_ID,
++	NCSI_ATTR_DATA,
+ 
+ 	__NCSI_ATTR_AFTER_LAST,
+ 	NCSI_ATTR_MAX = __NCSI_ATTR_AFTER_LAST - 1
+diff --git a/net/ncsi/internal.h b/net/ncsi/internal.h
+index 3d0a33b..13c9b5e 100644
+--- a/net/ncsi/internal.h
++++ b/net/ncsi/internal.h
+@@ -175,6 +175,8 @@ struct ncsi_package;
+ #define NCSI_RESERVED_CHANNEL	0x1f
+ #define NCSI_CHANNEL_INDEX(c)	((c) & ((1 << NCSI_PACKAGE_SHIFT) - 1))
+ #define NCSI_TO_CHANNEL(p, c)	(((p) << NCSI_PACKAGE_SHIFT) | (c))
++#define NCSI_MAX_PACKAGE	8
++#define NCSI_MAX_CHANNEL	32
+ 
+ struct ncsi_channel {
+ 	unsigned char               id;
+@@ -220,11 +222,15 @@ struct ncsi_request {
+ 	bool                 used;    /* Request that has been assigned  */
+ 	unsigned int         flags;   /* NCSI request property           */
+ #define NCSI_REQ_FLAG_EVENT_DRIVEN	1
++#define NCSI_REQ_FLAG_NETLINK_DRIVEN	2
+ 	struct ncsi_dev_priv *ndp;    /* Associated NCSI device          */
+ 	struct sk_buff       *cmd;    /* Associated NCSI command packet  */
+ 	struct sk_buff       *rsp;    /* Associated NCSI response packet */
+ 	struct timer_list    timer;   /* Timer on waiting for response   */
+ 	bool                 enabled; /* Time has been enabled or not    */
++	u32                  snd_seq;     /* netlink sending sequence number */
++	u32                  snd_portid;  /* netlink portid of sender        */
++	struct nlmsghdr      nlhdr;       /* netlink message header          */
+ };
+ 
+ enum {
+@@ -310,6 +316,7 @@ struct ncsi_cmd_arg {
+ 		unsigned int   dwords[4];
+ 	};
+ 	unsigned char        *data;       /* NCSI OEM data                 */
++	struct genl_info     *info;       /* Netlink information           */
+ };
+ 
+ extern struct list_head ncsi_dev_list;
+diff --git a/net/ncsi/ncsi-cmd.c b/net/ncsi/ncsi-cmd.c
+index 82b7d92..356af47 100644
+--- a/net/ncsi/ncsi-cmd.c
++++ b/net/ncsi/ncsi-cmd.c
+@@ -17,6 +17,7 @@
+ #include <net/ncsi.h>
+ #include <net/net_namespace.h>
+ #include <net/sock.h>
++#include <net/genetlink.h>
+ 
+ #include "internal.h"
+ #include "ncsi-pkt.h"
+@@ -346,6 +347,13 @@ int ncsi_xmit_cmd(struct ncsi_cmd_arg *nca)
+ 	if (!nr)
+ 		return -ENOMEM;
+ 
++	/* track netlink information */
++	if (nca->req_flags == NCSI_REQ_FLAG_NETLINK_DRIVEN) {
++		nr->snd_seq = nca->info->snd_seq;
++		nr->snd_portid = nca->info->snd_portid;
++		nr->nlhdr = *nca->info->nlhdr;
++	}
++
+ 	/* Prepare the packet */
+ 	nca->id = nr->id;
+ 	ret = nch->handler(nr->cmd, nca);
+diff --git a/net/ncsi/ncsi-manage.c b/net/ncsi/ncsi-manage.c
+index 0912847..6aa0614 100644
+--- a/net/ncsi/ncsi-manage.c
++++ b/net/ncsi/ncsi-manage.c
+@@ -19,6 +19,7 @@
+ #include <net/addrconf.h>
+ #include <net/ipv6.h>
+ #include <net/if_inet6.h>
++#include <net/genetlink.h>
+ 
+ #include "internal.h"
+ #include "ncsi-pkt.h"
+@@ -406,6 +407,9 @@ static void ncsi_request_timeout(struct timer_list *t)
+ {
+ 	struct ncsi_request *nr = from_timer(nr, t, timer);
+ 	struct ncsi_dev_priv *ndp = nr->ndp;
++	struct ncsi_cmd_pkt *cmd;
++	struct ncsi_package *np;
++	struct ncsi_channel *nc;
+ 	unsigned long flags;
+ 
+ 	/* If the request already had associated response,
+@@ -419,6 +423,18 @@ static void ncsi_request_timeout(struct timer_list *t)
+ 	}
+ 	spin_unlock_irqrestore(&ndp->lock, flags);
+ 
++	if (nr->flags == NCSI_REQ_FLAG_NETLINK_DRIVEN) {
++		if (nr->cmd) {
++			/* Find the package */
++			cmd = (struct ncsi_cmd_pkt *)
++			      skb_network_header(nr->cmd);
++			ncsi_find_package_and_channel(ndp,
++						      cmd->cmd.common.channel,
++						      &np, &nc);
++			ncsi_send_netlink_timeout(nr, np, nc);
++		}
++	}
++
+ 	/* Release the request */
+ 	ncsi_free_request(nr);
+ }
+diff --git a/net/ncsi/ncsi-netlink.c b/net/ncsi/ncsi-netlink.c
+index 45f33d6..9b48b9f 100644
+--- a/net/ncsi/ncsi-netlink.c
++++ b/net/ncsi/ncsi-netlink.c
+@@ -20,6 +20,7 @@
+ #include <uapi/linux/ncsi.h>
+ 
+ #include "internal.h"
++#include "ncsi-pkt.h"
+ #include "ncsi-netlink.h"
+ 
+ static struct genl_family ncsi_genl_family;
+@@ -29,6 +30,7 @@ static const struct nla_policy ncsi_genl_policy[NCSI_ATTR_MAX + 1] = {
+ 	[NCSI_ATTR_PACKAGE_LIST] =	{ .type = NLA_NESTED },
+ 	[NCSI_ATTR_PACKAGE_ID] =	{ .type = NLA_U32 },
+ 	[NCSI_ATTR_CHANNEL_ID] =	{ .type = NLA_U32 },
++	[NCSI_ATTR_DATA] =		{ .type = NLA_BINARY, .len = 2048 },
+ };
+ 
+ static struct ncsi_dev_priv *ndp_from_ifindex(struct net *net, u32 ifindex)
+@@ -366,6 +368,202 @@ static int ncsi_clear_interface_nl(struct sk_buff *msg, struct genl_info *info)
+ 	return 0;
+ }
+ 
++static int ncsi_send_cmd_nl(struct sk_buff *msg, struct genl_info *info)
++{
++	struct ncsi_dev_priv *ndp;
++	struct ncsi_pkt_hdr *hdr;
++	struct ncsi_cmd_arg nca;
++	unsigned char *data;
++	u32 package_id;
++	u32 channel_id;
++	int len, ret;
++
++	if (!info || !info->attrs) {
++		ret = -EINVAL;
++		goto out;
++	}
++
++	if (!info->attrs[NCSI_ATTR_IFINDEX]) {
++		ret = -EINVAL;
++		goto out;
++	}
++
++	if (!info->attrs[NCSI_ATTR_PACKAGE_ID]) {
++		ret = -EINVAL;
++		goto out;
++	}
++
++	if (!info->attrs[NCSI_ATTR_CHANNEL_ID]) {
++		ret = -EINVAL;
++		goto out;
++	}
++
++	if (!info->attrs[NCSI_ATTR_DATA]) {
++		ret = -EINVAL;
++		goto out;
++	}
++
++	ndp = ndp_from_ifindex(get_net(sock_net(msg->sk)),
++			       nla_get_u32(info->attrs[NCSI_ATTR_IFINDEX]));
++	if (!ndp) {
++		ret = -ENODEV;
++		goto out;
++	}
++
++	package_id = nla_get_u32(info->attrs[NCSI_ATTR_PACKAGE_ID]);
++	channel_id = nla_get_u32(info->attrs[NCSI_ATTR_CHANNEL_ID]);
++
++	if (package_id >= NCSI_MAX_PACKAGE || channel_id >= NCSI_MAX_CHANNEL) {
++		ret = -ERANGE;
++		goto out_netlink;
++	}
++
++	len = nla_len(info->attrs[NCSI_ATTR_DATA]);
++	if (len < sizeof(struct ncsi_pkt_hdr)) {
++		netdev_info(ndp->ndev.dev, "NCSI: no command to send %u\n",
++			    package_id);
++		ret = -EINVAL;
++		goto out_netlink;
++	} else {
++		data = (unsigned char *)nla_data(info->attrs[NCSI_ATTR_DATA]);
++	}
++
++	hdr = (struct ncsi_pkt_hdr *)data;
++
++	nca.ndp = ndp;
++	nca.package = (unsigned char)package_id;
++	nca.channel = (unsigned char)channel_id;
++	nca.type = hdr->type;
++	nca.req_flags = NCSI_REQ_FLAG_NETLINK_DRIVEN;
++	nca.info = info;
++	nca.payload = ntohs(hdr->length);
++	nca.data = data + sizeof(*hdr);
++
++	ret = ncsi_xmit_cmd(&nca);
++out_netlink:
++	if (ret != 0) {
++		netdev_err(ndp->ndev.dev,
++			   "NCSI: Error %d sending command\n",
++			   ret);
++		ncsi_send_netlink_err(ndp->ndev.dev,
++				      info->snd_seq,
++				      info->snd_portid,
++				      info->nlhdr,
++				      ret);
++	}
++out:
++	return ret;
++}
++
++int ncsi_send_netlink_rsp(struct ncsi_request *nr,
++			  struct ncsi_package *np,
++			  struct ncsi_channel *nc)
++{
++	struct sk_buff *skb;
++	struct net *net;
++	void *hdr;
++	int rc;
++
++	net = dev_net(nr->rsp->dev);
++
++	skb = genlmsg_new(NLMSG_DEFAULT_SIZE, GFP_ATOMIC);
++	if (!skb)
++		return -ENOMEM;
++
++	hdr = genlmsg_put(skb, nr->snd_portid, nr->snd_seq,
++			  &ncsi_genl_family, 0, NCSI_CMD_SEND_CMD);
++	if (!hdr) {
++		kfree_skb(skb);
++		return -EMSGSIZE;
++	}
++
++	nla_put_u32(skb, NCSI_ATTR_IFINDEX, nr->rsp->dev->ifindex);
++	if (np)
++		nla_put_u32(skb, NCSI_ATTR_PACKAGE_ID, np->id);
++	if (nc)
++		nla_put_u32(skb, NCSI_ATTR_CHANNEL_ID, nc->id);
++	else
++		nla_put_u32(skb, NCSI_ATTR_CHANNEL_ID, NCSI_RESERVED_CHANNEL);
++
++	rc = nla_put(skb, NCSI_ATTR_DATA, nr->rsp->len, (void *)nr->rsp->data);
++	if (rc)
++		goto err;
++
++	genlmsg_end(skb, hdr);
++	return genlmsg_unicast(net, skb, nr->snd_portid);
++
++err:
++	kfree_skb(skb);
++	return rc;
++}
++
++int ncsi_send_netlink_timeout(struct ncsi_request *nr,
++			      struct ncsi_package *np,
++			      struct ncsi_channel *nc)
++{
++	struct sk_buff *skb;
++	struct net *net;
++	void *hdr;
++
++	skb = genlmsg_new(NLMSG_DEFAULT_SIZE, GFP_ATOMIC);
++	if (!skb)
++		return -ENOMEM;
++
++	hdr = genlmsg_put(skb, nr->snd_portid, nr->snd_seq,
++			  &ncsi_genl_family, 0, NCSI_CMD_SEND_CMD);
++	if (!hdr) {
++		kfree_skb(skb);
++		return -EMSGSIZE;
++	}
++
++	net = dev_net(nr->cmd->dev);
++
++	nla_put_u32(skb, NCSI_ATTR_IFINDEX, nr->cmd->dev->ifindex);
++
++	if (np)
++		nla_put_u32(skb, NCSI_ATTR_PACKAGE_ID, np->id);
++	else
++		nla_put_u32(skb, NCSI_ATTR_PACKAGE_ID,
++			    NCSI_PACKAGE_INDEX((((struct ncsi_pkt_hdr *)
++						 nr->cmd->data)->channel)));
++
++	if (nc)
++		nla_put_u32(skb, NCSI_ATTR_CHANNEL_ID, nc->id);
++	else
++		nla_put_u32(skb, NCSI_ATTR_CHANNEL_ID, NCSI_RESERVED_CHANNEL);
++
++	genlmsg_end(skb, hdr);
++	return genlmsg_unicast(net, skb, nr->snd_portid);
++}
++
++int ncsi_send_netlink_err(struct net_device *dev,
++			  u32 snd_seq,
++			  u32 snd_portid,
++			  struct nlmsghdr *nlhdr,
++			  int err)
++{
++	struct nlmsghdr *nlh;
++	struct nlmsgerr *nle;
++	struct sk_buff *skb;
++	struct net *net;
++
++	skb = nlmsg_new(NLMSG_DEFAULT_SIZE, GFP_ATOMIC);
++	if (!skb)
++		return -ENOMEM;
++
++	net = dev_net(dev);
++
++	nlh = nlmsg_put(skb, snd_portid, snd_seq,
++			NLMSG_ERROR, sizeof(*nle), 0);
++	nle = (struct nlmsgerr *)nlmsg_data(nlh);
++	nle->error = err;
++	memcpy(&nle->msg, nlhdr, sizeof(*nlh));
++
++	nlmsg_end(skb, nlh);
++
++	return nlmsg_unicast(net->genl_sock, skb, snd_portid);
++}
++
+ static const struct genl_ops ncsi_ops[] = {
+ 	{
+ 		.cmd = NCSI_CMD_PKG_INFO,
+@@ -386,6 +584,12 @@ static const struct genl_ops ncsi_ops[] = {
+ 		.doit = ncsi_clear_interface_nl,
+ 		.flags = GENL_ADMIN_PERM,
+ 	},
++	{
++		.cmd = NCSI_CMD_SEND_CMD,
++		.policy = ncsi_genl_policy,
++		.doit = ncsi_send_cmd_nl,
++		.flags = GENL_ADMIN_PERM,
++	},
+ };
+ 
+ static struct genl_family ncsi_genl_family __ro_after_init = {
+diff --git a/net/ncsi/ncsi-netlink.h b/net/ncsi/ncsi-netlink.h
+index 91a5c25..c4a4688 100644
+--- a/net/ncsi/ncsi-netlink.h
++++ b/net/ncsi/ncsi-netlink.h
+@@ -14,6 +14,18 @@
+ 
+ #include "internal.h"
+ 
++int ncsi_send_netlink_rsp(struct ncsi_request *nr,
++			  struct ncsi_package *np,
++			  struct ncsi_channel *nc);
++int ncsi_send_netlink_timeout(struct ncsi_request *nr,
++			      struct ncsi_package *np,
++			      struct ncsi_channel *nc);
++int ncsi_send_netlink_err(struct net_device *dev,
++			  u32 snd_seq,
++			  u32 snd_portid,
++			  struct nlmsghdr *nlhdr,
++			  int err);
++
+ int ncsi_init_netlink(struct net_device *dev);
+ int ncsi_unregister_netlink(struct net_device *dev);
+ 
+diff --git a/net/ncsi/ncsi-rsp.c b/net/ncsi/ncsi-rsp.c
+index d66b347..85fa59a 100644
+--- a/net/ncsi/ncsi-rsp.c
++++ b/net/ncsi/ncsi-rsp.c
+@@ -16,9 +16,11 @@
+ #include <net/ncsi.h>
+ #include <net/net_namespace.h>
+ #include <net/sock.h>
++#include <net/genetlink.h>
+ 
+ #include "internal.h"
+ #include "ncsi-pkt.h"
++#include "ncsi-netlink.h"
+ 
+ static int ncsi_validate_rsp_pkt(struct ncsi_request *nr,
+ 				 unsigned short payload)
+@@ -32,15 +34,25 @@ static int ncsi_validate_rsp_pkt(struct ncsi_request *nr,
+ 	 * before calling this function.
+ 	 */
+ 	h = (struct ncsi_rsp_pkt_hdr *)skb_network_header(nr->rsp);
+-	if (h->common.revision != NCSI_PKT_REVISION)
++
++	if (h->common.revision != NCSI_PKT_REVISION) {
++		netdev_dbg(nr->ndp->ndev.dev,
++			   "NCSI: unsupported header revision\n");
+ 		return -EINVAL;
+-	if (ntohs(h->common.length) != payload)
++	}
++	if (ntohs(h->common.length) != payload) {
++		netdev_dbg(nr->ndp->ndev.dev,
++			   "NCSI: payload length mismatched\n");
+ 		return -EINVAL;
++	}
+ 
+ 	/* Check on code and reason */
+ 	if (ntohs(h->code) != NCSI_PKT_RSP_C_COMPLETED ||
+-	    ntohs(h->reason) != NCSI_PKT_RSP_R_NO_ERROR)
+-		return -EINVAL;
++	    ntohs(h->reason) != NCSI_PKT_RSP_R_NO_ERROR) {
++		netdev_dbg(nr->ndp->ndev.dev,
++			   "NCSI: non zero response/reason code\n");
++		return -EPERM;
++	}
+ 
+ 	/* Validate checksum, which might be zeroes if the
+ 	 * sender doesn't support checksum according to NCSI
+@@ -52,8 +64,11 @@ static int ncsi_validate_rsp_pkt(struct ncsi_request *nr,
+ 
+ 	checksum = ncsi_calculate_checksum((unsigned char *)h,
+ 					   sizeof(*h) + payload - 4);
+-	if (*pchecksum != htonl(checksum))
++
++	if (*pchecksum != htonl(checksum)) {
++		netdev_dbg(nr->ndp->ndev.dev, "NCSI: checksum mismatched\n");
+ 		return -EINVAL;
++	}
+ 
+ 	return 0;
+ }
+@@ -941,6 +956,26 @@ static int ncsi_rsp_handler_gpuuid(struct ncsi_request *nr)
+ 	return 0;
+ }
+ 
++static int ncsi_rsp_handler_netlink(struct ncsi_request *nr)
++{
++	struct ncsi_dev_priv *ndp = nr->ndp;
++	struct ncsi_rsp_pkt *rsp;
++	struct ncsi_package *np;
++	struct ncsi_channel *nc;
++	int ret;
++
++	/* Find the package */
++	rsp = (struct ncsi_rsp_pkt *)skb_network_header(nr->rsp);
++	ncsi_find_package_and_channel(ndp, rsp->rsp.common.channel,
++				      &np, &nc);
++	if (!np)
++		return -ENODEV;
++
++	ret = ncsi_send_netlink_rsp(nr, np, nc);
++
++	return ret;
++}
++
+ static struct ncsi_rsp_handler {
+ 	unsigned char	type;
+ 	int             payload;
+@@ -1043,6 +1078,17 @@ int ncsi_rcv_rsp(struct sk_buff *skb, struct net_device *dev,
+ 		netdev_warn(ndp->ndev.dev,
+ 			    "NCSI: 'bad' packet ignored for type 0x%x\n",
+ 			    hdr->type);
++
++		if (nr->flags == NCSI_REQ_FLAG_NETLINK_DRIVEN) {
++			if (ret == -EPERM)
++				goto out_netlink;
++			else
++				ncsi_send_netlink_err(ndp->ndev.dev,
++						      nr->snd_seq,
++						      nr->snd_portid,
++						      &nr->nlhdr,
++						      ret);
++		}
+ 		goto out;
+ 	}
+ 
+@@ -1052,6 +1098,17 @@ int ncsi_rcv_rsp(struct sk_buff *skb, struct net_device *dev,
+ 		netdev_err(ndp->ndev.dev,
+ 			   "NCSI: Handler for packet type 0x%x returned %d\n",
+ 			   hdr->type, ret);
++
++out_netlink:
++	if (nr->flags == NCSI_REQ_FLAG_NETLINK_DRIVEN) {
++		ret = ncsi_rsp_handler_netlink(nr);
++		if (ret) {
++			netdev_err(ndp->ndev.dev,
++				   "NCSI: Netlink handler for packet type 0x%x returned %d\n",
++				   hdr->type, ret);
++		}
++	}
++
+ out:
+ 	ncsi_free_request(nr);
+ 	return ret;

--- a/linux-patches/05-mac-for-cx3.diff
+++ b/linux-patches/05-mac-for-cx3.diff
@@ -1,0 +1,70 @@
+diff --git a/net/ncsi/internal.h b/net/ncsi/internal.h
+index 71670d3270f3..6dc306aab661 100644
+--- a/net/ncsi/internal.h
++++ b/net/ncsi/internal.h
+@@ -75,13 +75,12 @@ enum {
+ #define NCSI_OEM_BCM_CMD_GMA            0x01   /* CMD ID for Get MAC */
+ /* Mellanox specific OEM Command */
+ #define NCSI_OEM_MLX_CMD_GMA            0x00   /* CMD ID for Get MAC */
+-#define NCSI_OEM_MLX_CMD_GMA_PARAM      0x1b   /* Parameter for GMA  */
+ /* OEM Command payload lengths*/
+ #define NCSI_OEM_BCM_CMD_GMA_LEN        12
+-#define NCSI_OEM_MLX_CMD_GMA_LEN        8
++#define NCSI_OEM_MLX_CMD_GMA_LEN        7
+ /* Mac address offset in OEM response */
+ #define BCM_MAC_ADDR_OFFSET             28
+-#define MLX_MAC_ADDR_OFFSET             8
++#define MLX_MAC_ADDR_OFFSET             4
+ 
+ 
+ struct ncsi_channel_version {
+diff --git a/net/ncsi/ncsi-cmd.c b/net/ncsi/ncsi-cmd.c
+index 356af474e43c..9b7ebc6fe20c 100644
+--- a/net/ncsi/ncsi-cmd.c
++++ b/net/ncsi/ncsi-cmd.c
+@@ -54,6 +54,10 @@ static void ncsi_cmd_build_header(struct ncsi_pkt_hdr *h,
+ 	h->reserved1[0] = 0;
+ 	h->reserved1[1] = 0;
+ 
++	if (nca->type == NCSI_PKT_CMD_OEM) {
++		return;
++	}
++
+ 	/* Fill with calculated checksum */
+ 	checksum = ncsi_calculate_checksum((unsigned char *)h,
+ 					   sizeof(*h) + nca->payload);
+diff --git a/net/ncsi/ncsi-manage.c b/net/ncsi/ncsi-manage.c
+index 961ff26dfd4c..3def8531cf89 100644
+--- a/net/ncsi/ncsi-manage.c
++++ b/net/ncsi/ncsi-manage.c
+@@ -684,7 +684,6 @@ static void ncsi_oem_gma_handler_mlx(struct ncsi_cmd_arg *nca)
+ 	memset(data, 0, NCSI_OEM_MLX_CMD_GMA_LEN);
+ 	*(unsigned int *)data = ntohl(NCSI_OEM_MFR_MLX_ID);
+ 	data[5] = NCSI_OEM_MLX_CMD_GMA;
+-	data[6] = NCSI_OEM_MLX_CMD_GMA_PARAM;
+ 
+ 	nca->data = data;
+ 
+diff --git a/net/ncsi/ncsi-rsp.c b/net/ncsi/ncsi-rsp.c
+index 56145f9fc92d..3ee5f18454ae 100644
+--- a/net/ncsi/ncsi-rsp.c
++++ b/net/ncsi/ncsi-rsp.c
+@@ -627,6 +627,8 @@ static int ncsi_rsp_handler_oem_mlx_gma(struct ncsi_request *nr)
+ 	saddr.sa_family = ndev->type;
+ 	ndev->priv_flags |= IFF_LIVE_ADDR_CHANGE;
+ 	memcpy(saddr.sa_data, &rsp->data[MLX_MAC_ADDR_OFFSET], ETH_ALEN);
++	/* Management MAC is reply +2 and does never appear to wrap byte boundary */
++	saddr.sa_data[5] += 2;
+ 	ret = ops->ndo_set_mac_address(ndev, &saddr);
+ 	if (ret < 0)
+ 		netdev_warn(ndev, "NCSI: Writing mac address to device failed\n");
+@@ -644,8 +646,7 @@ static int ncsi_rsp_handler_oem_mlx(struct ncsi_request *nr)
+ 	rsp = (struct ncsi_rsp_oem_pkt *)skb_network_header(nr->rsp);
+ 	mlx = (struct ncsi_rsp_oem_mlx_pkt *)(rsp->data);
+ 
+-	if (mlx->cmd == NCSI_OEM_MLX_CMD_GMA &&
+-	    mlx->param == NCSI_OEM_MLX_CMD_GMA_PARAM)
++	if (mlx->cmd == NCSI_OEM_MLX_CMD_GMA)
+ 		return ncsi_rsp_handler_oem_mlx_gma(nr);
+ 	return 0;
+ }

--- a/linux-patches/README.md
+++ b/linux-patches/README.md
@@ -1,0 +1,4 @@
+# Linux patches
+
+These are patches that are in the process of being upstreamed but needs to
+be patched now to support some critical functionallity.

--- a/linux-patches/apply.sh
+++ b/linux-patches/apply.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Copyright 2018 u-root Authors
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file
+
+dir=$(dirname $0)
+
+for i in $(ls ${dir}/*.diff)
+do
+  patch -p1 < $i
+done

--- a/linux.config
+++ b/linux.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 4.18.8 Kernel Configuration
+# Linux/arm 4.18.12 Kernel Configuration
 #
 
 #
@@ -706,6 +706,7 @@ CONFIG_VLAN_8021Q=y
 # CONFIG_NET_SWITCHDEV is not set
 # CONFIG_NET_L3_MASTER_DEV is not set
 CONFIG_NET_NCSI=y
+CONFIG_NCSI_OEM_CMD_GET_MAC=y
 # CONFIG_CGROUP_NET_PRIO is not set
 # CONFIG_CGROUP_NET_CLASSID is not set
 CONFIG_NET_RX_BUSY_POLL=y

--- a/platform/quanta-f06-leopard-ddr3.dts
+++ b/platform/quanta-f06-leopard-ddr3.dts
@@ -10,7 +10,7 @@
 
 	chosen {
 		stdout-path = &uart5;
-		bootargs = "console=ttyS4,57600n8 earlyprintk panic=1 root=/dev/ram0 rdinit=/loader mtdparts=nor.flash:512k(u-boot),-(ubi) ubi.mtd=ubi";
+		bootargs = "console=ttyS4,57600n8 earlyprintk panic=1 root=/dev/ram0 rdinit=/loader mtdparts=nor.flash:512k(u-boot),-(ubi) ubi.mtd=ubi dyndbg=\"file net/ncsi/* +p\"";
 	};
 
 	memory@40000000 {


### PR DESCRIPTION
This is a modification of the to-be-upstreamed patches to support the
CX3 series of cards.

It also enables more debug for NCSI on boot time.

This fixed #73.