### PR TITLE
Change reboot signature in integration test

### DIFF
--- a/integration/boot_test.go
+++ b/integration/boot_test.go
@@ -32,7 +32,7 @@ func TestVerifyFail(t *testing.T) {
 		t.Fatal(`expected "invalid signature: hash tag doesn't match", got error: `, err)
 	}
 	// Make sure the system rebooted in response to the error
-	if err := q.Expect("DRAM Init-DDR3"); err != nil {
-		t.Fatal(`expected reboot signature "DRAM Init-DDR3", got error: `, err)
+	if err := q.Expect("Hit any key to stop autoboot"); err != nil {
+		t.Fatal(`expected reboot signature "Hit any key to stop autoboot", got error: `, err)
 	}
 }


### PR DESCRIPTION
For some reason the DRAM Init-DDR3 message has disappeared. Change it to
another one that is always there.

Signed-off-by: Christian Svensson <bluecmd@google.com>