### PR TITLE
Disable Global Multicast Filtering

### DIFF
--- a/linux-patches/03-Disable-Global-Multicast-Filtering.patch
+++ b/linux-patches/03-Disable-Global-Multicast-Filtering.patch
@@ -1,0 +1,38 @@
+From 8a1698754b722761f58a110830b1ac5aeb560cfa Mon Sep 17 00:00:00 2001
+From: Christian Svensson <bluecmd@google.com>
+Date: Sat, 3 Nov 2018 22:50:04 +0100
+Subject: [PATCH] Disable Global Multicast Filtering
+
+See https://github.com/u-root/u-bmc/issues/92.
+TL;DR: IPv6 breaks on at least Mellanox CX3.
+
+Signed-off-by: Christian Svensson <bluecmd@google.com>
+---
+ net/ncsi/ncsi-manage.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/net/ncsi/ncsi-manage.c b/net/ncsi/ncsi-manage.c
+index a91ee47e84b0..ae67b4f9a48b 100644
+--- a/net/ncsi/ncsi-manage.c
++++ b/net/ncsi/ncsi-manage.c
+@@ -868,7 +868,7 @@ static void ncsi_configure_channel(struct ncsi_dev_priv *ndp)
+ 			nca.type = NCSI_PKT_CMD_EBF;
+ 			nca.dwords[0] = nc->caps[NCSI_CAP_BC].cap;
+ 			nd->state = ncsi_dev_state_config_ecnt;
+-#if IS_ENABLED(CONFIG_IPV6)
++#if 0
+ 			if (ndp->inet6_addr_num > 0 &&
+ 			    (nc->caps[NCSI_CAP_GENERIC].cap &
+ 			     NCSI_CAP_GENERIC_MC))
+@@ -1370,7 +1370,7 @@ static int ncsi_inet6addr_event(struct notifier_block *this,
+ 	switch (event) {
+ 	case NETDEV_UP:
+ 		action = (++ndp->inet6_addr_num) == 1;
+-		nca.type = NCSI_PKT_CMD_EGMF;
++		nca.type = NCSI_PKT_CMD_DGMF;
+ 		break;
+ 	case NETDEV_DOWN:
+ 		action = (--ndp->inet6_addr_num == 0);
+-- 
+2.19.1.930.g4563a0d9d0-goog
+


### PR DESCRIPTION
Fixes #92, see the issue for the reason behind.
TL;DR: A lot of multicast traffic gets filtered that should not.

Signed-off-by: Christian Svensson <bluecmd@google.com>