### PR TITLE
ubmcctl: Support client streaming RPCs

### DIFF
--- a/cmd/ubmcctl/README.md
+++ b/cmd/ubmcctl/README.md
@@ -15,3 +15,11 @@ Get current fan settings:
 ```
 ubmcctl --host 10.0.10.20 GetFans
 ```
+
+Stream the host console:
+
+```
+ubmcctl StreamConsole -
+# Console output will now stream in protobuf ascii form
+# You can send data by writing e.g. 'data: "hello\n"'
+```


### PR DESCRIPTION
Enable using '-' to mark reading from stdin for streaming RPCs.
