### PR TITLE
gofmt: Fix format checking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
           command: go vet $(go list ./... | grep -v /vendor/)
       - run:
           name: gofmt
-          command: test -z $(gofmt -s -l $(go list ./... | grep -v /vendor/))
+          command: test -z "$(gofmt -s -l $(go list ./... | grep -v /vendor/ | cut -f 4- -d '/'))"
       - run:
           name: ineffassign
           command: ineffassign .

--- a/boot/loader/main.go
+++ b/boot/loader/main.go
@@ -30,8 +30,8 @@ const (
 	pubKeyPath = "/u-bmc.pub"
 	// TODO(bluecmd): We cannot chroot into /mnt since we have to run /kexec
 	// for now.
-	kernelPath  = "/mnt/boot/zImage"
-	dtbPath     = "/mnt/boot/platform.dtb"
+	kernelPath = "/mnt/boot/zImage"
+	dtbPath    = "/mnt/boot/platform.dtb"
 )
 
 var (

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -15,12 +15,12 @@ import (
 	"testing"
 	"time"
 
+	urootint "github.com/u-root/u-root/integration"
 	"github.com/u-root/u-root/pkg/golang"
 	"github.com/u-root/u-root/pkg/qemu"
 	"github.com/u-root/u-root/pkg/uroot"
 	"github.com/u-root/u-root/pkg/uroot/builder"
 	"github.com/u-root/u-root/pkg/uroot/initramfs"
-	urootint "github.com/u-root/u-root/integration"
 )
 
 const (
@@ -60,7 +60,6 @@ func (d MachineDevice) Cmdline() []string {
 	return []string{"-M", d.Board}
 }
 
-
 func BMCTest(t *testing.T, o *Options) (*qemu.VM, func()) {
 	if _, ok := os.LookupEnv("UBMC_QEMU"); !ok {
 		t.Skip("test is skipped unless UBMC_QEMU is set")
@@ -86,7 +85,7 @@ func BMCTest(t *testing.T, o *Options) (*qemu.VM, func()) {
 	_ = buildInitramfs(t, tmpDir, o)
 	flash := buildFlash(t, tmpDir, o)
 	q := &qemu.Options{
-		QEMUPath:  os.Getenv("UBMC_QEMU"),
+		QEMUPath: os.Getenv("UBMC_QEMU"),
 		// TODO(bluecmd): Right now only one platform is supported for tests
 		Devices: []qemu.Device{
 			MachineDevice{"palmetto-bmc"},
@@ -128,7 +127,6 @@ func NativeTest(t *testing.T, o *Options) (*qemu.VM, func()) {
 		Initramfs: i,
 		Kernel:    os.Getenv("UBMC_NATIVE_BZIMAGE"),
 		QEMUPath:  os.Getenv("UBMC_NATIVE_QEMU"),
-
 	}
 	vm, vmCleanup := qemuTest(t, q, o)
 
@@ -152,14 +150,14 @@ func buildInitramfs(t *testing.T, tmpDir string, o *Options) string {
 		Env: *o.Env,
 		Commands: []uroot.Commands{
 			{
-				Builder: builder.BusyBox,
+				Builder:  builder.BusyBox,
 				Packages: o.Cmds,
 			},
 		},
-		TempDir:      tmpDir,
-		BaseArchive:  uroot.DefaultRamfs.Reader(),
-		OutputFile:   w,
-		InitCmd:      "init",
+		TempDir:     tmpDir,
+		BaseArchive: uroot.DefaultRamfs.Reader(),
+		OutputFile:  w,
+		InitCmd:     "init",
 	}
 	if err := uroot.CreateInitramfs(logger, opts); err != nil {
 		t.Fatal(err)

--- a/pkg/aspeed/gpio_reg.go
+++ b/pkg/aspeed/gpio_reg.go
@@ -434,10 +434,10 @@ func (a *Ast) SnapshotGpio() *State {
 	s := State{}
 	s.Gpio = make(map[uint32]uint32)
 	s.Scu = make(map[uint32]uint32)
-	for r, _ := range gpioDirRegs {
+	for r := range gpioDirRegs {
 		s.Gpio[r] = a.Mem().MustRead32(base + uintptr(r))
 	}
-	for r, _ := range gpioDataRegs {
+	for r := range gpioDataRegs {
 		s.Gpio[r] = a.Mem().MustRead32(base + uintptr(r))
 	}
 	for _, r := range scuGpioRegs {

--- a/pkg/bmc/ttime/roughtime.go
+++ b/pkg/bmc/ttime/roughtime.go
@@ -46,7 +46,7 @@ func getOneRoughtime(rs []RoughtimeServer) *roughtime.Roughtime {
 			PublicKeyType: r.PublicKeyType,
 			PublicKey:     pk,
 			Addresses: []config.ServerAddress{
-				config.ServerAddress{Protocol: r.Protocol, Address: r.Address},
+				{Protocol: r.Protocol, Address: r.Address},
 			}}
 		g.Go(func() error {
 			res, err := roughtime.Get(srv, roughtimeAttempts, roughtimeTimeout, nil)

--- a/pkg/roughtime/client.go
+++ b/pkg/roughtime/client.go
@@ -263,7 +263,7 @@ func (r *Result) Error() error {
 func Do(servers []config.Server, attempts int, timeout time.Duration, prev *Roughtime) []Result {
 	results := make([]Result, len(servers))
 	var delay time.Duration
-	for i, _ := range servers {
+	for i := range servers {
 		start := time.Now()
 		srv := &servers[i]
 		rt, err := Get(srv, attempts, timeout, prev)

--- a/pkg/roughtime/upstream/protocol/protocol_test.go
+++ b/pkg/roughtime/upstream/protocol/protocol_test.go
@@ -167,8 +167,8 @@ func TestChaining(t *testing.T) {
 	}
 
 	claim := []claimStep{
-		claimStep{rootPublicKeyA, nonce1, replies1[0]},
-		claimStep{rootPublicKeyB, blind2, replies2[0]},
+		{rootPublicKeyA, nonce1, replies1[0]},
+		{rootPublicKeyB, blind2, replies2[0]},
 	}
 
 	// In order to verify a claim, one would check each of the replies

--- a/platform/cmd/boot-config/main.go
+++ b/platform/cmd/boot-config/main.go
@@ -45,7 +45,7 @@ func main() {
 	dtbStart := (ramEnd - dtb.Size()) & ^0x3
 	// Align to 64 KiB to make the kernel happy
 	initrdEnd := (dtbStart - 64*1024)
-	initrdStart := (initrdEnd - initrd.Size()) & ^(64*1024-1)
+	initrdStart := (initrdEnd - initrd.Size()) & ^(64*1024 - 1)
 	initrdEnd = initrdStart + initrd.Size()
 
 	fmt.Printf(`


### PR DESCRIPTION
Something has changed with gofmt lately requiring us to drop the prefix
of paths. Do this, and fix the current issues that have snuck in.
