### PR TITLE
ovmf: Copy OVMF ROM and license from fiano

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,3 +259,10 @@ pebble:
 	PEBBLE_VA_ALWAYS_VALID=1 go run github.com/letsencrypt/pebble/cmd/pebble \
 		-dnsserver locahost:6053 \
 		-config config/sim-pebble.json
+
+run-ovmf:
+	qemu-system-x86_64 -bios $(ROOT_DIR)integration/ovmf.rom \
+		-display none \
+		-chardev socket,id=host,path=host.uart \
+		-serial chardev:host \
+		-net none

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Trying out u-bmc is easiest using the simulator. To launch it, run:
 ```
 # Launch a local ACME server
 make pebble &
+# (Optional) Launch a local emulated BIOS to produce some data on the UART
+make run-ovmf &
 # Launch u-bmc simulator
 make sim
 ```

--- a/integration/ovmf.md
+++ b/integration/ovmf.md
@@ -1,0 +1,32 @@
+# OVMF
+
+OVMF is used to provide realistic data on the UART line when running u-bmc
+in a simulator.
+
+EDK2 is open-source UEFI firmware, governed under a BSD license and can be
+redistributed. OVMF is a EDK2 configuration which can run under QEMU.
+
+## Build Notes
+
+- OS: `Ubuntu 16.04.4 LTS xenial`
+- Git tag: `vUDK2018`
+- GCC version: `gcc (Ubuntu 5.4.0-6ubuntu1~16.04.10) 5.4.0 20160609`
+- Build is not reproducible.
+- Find instructions at: https://wiki.ubuntu.com/UEFI/EDK2
+
+Parameters:
+
+```
+ACTIVE_PLATFORM       = OvmfPkg/OvmfPkgX64.dsc
+BUILD_RULE_CONF       = Conf/build_rule.txt
+TARGET_ARCH           = X64
+TARGET                = DEBUG
+TOOL_CHAIN_CONF       = Conf/tools_def.txt
+TOOL_CHAIN_TAG        = GCC5
+```
+
+## Running in QEMU
+
+```
+qemu-system-x86_64 -bios ovmf.rom -nographic -net none
+```


### PR DESCRIPTION
Use OVMF to provide a realistic serial port data stream for development
of a SoL client.

This helps #138